### PR TITLE
Automate implicit lens

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ addCompilerPlugin("io.tryp" % "splain" % "0.3.1" cross CrossVersion.patch)
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")
 
+addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full)
+
 scalacOptions ++= Seq(
   "-Xlint",
   "-unchecked",
@@ -24,3 +26,9 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",
   "com.chuusai" %% "shapeless" % "2.3.3")
 
+val monocleVersion = "1.5.0"
+
+libraryDependencies ++= Seq(
+  "com.github.julien-truffaut" %%  "monocle-core"  % monocleVersion,
+  "com.github.julien-truffaut" %%  "monocle-macro" % monocleVersion,
+  "com.github.julien-truffaut" %%  "monocle-law"   % monocleVersion % "test")

--- a/src/main/scala/Core.scala
+++ b/src/main/scala/Core.scala
@@ -125,6 +125,8 @@ object Util {
 
   object AlgFunctor {
 
+    def apply[Alg[_[_], _]](implicit ev: AlgFunctor[Alg]): AlgFunctor[Alg] = ev
+
     // XXX: boilerplate instances, consider using Shapeless here?
     
     implicit val GetterAlgFunctor = new AlgFunctor[Getter] {
@@ -193,12 +195,10 @@ object Util {
         rInstance: Lazy[GetEvidence[R]]): GetEvidence[A] =
       GetEvidence[A](generic.from(rInstance.value.apply))
   
-    // XXX: perhaps this isn't the best idea, but it's what I needed while
-    // debugging implicits with *splain*.
     implicit def genericGetEvidence2[K, A, R](implicit
         generic: LabelledGeneric.Aux[A, R],
         rInstance: Lazy[GetEvidence[R]]): GetEvidence[FieldType[K, A]] =
-      GetEvidence[FieldType[K, A]](field[K](generic.from(rInstance.value.apply)))
+      GetEvidence[FieldType[K, A]](field[K](genericGetEvidence[A, R].apply)),
   }
 }
  

--- a/src/main/scala/Core.scala
+++ b/src/main/scala/Core.scala
@@ -103,11 +103,10 @@ object Util {
   def lensId[S]: Lens[S, S] = NaturalTransformation.refl
   
   implicit def self[A] = 'self ->> lensId[A]
-  
-  implicit def compNat[P[_], Q[_], R[_]](implicit
-      nat1: Q ~> P, 
-      nat2: R ~> Q): R ~> P =
-    nat1 compose nat2
+
+  implicit def symbolLensAsNat[K, S, A](implicit 
+      ev: FieldType[K, monocle.Lens[S, A]]): FieldType[K, Lens[S, A]] =
+    field[K](ev.natural)
 
   // Lens & StateField are isomorphic
 

--- a/src/main/scala/Core.scala
+++ b/src/main/scala/Core.scala
@@ -125,7 +125,8 @@ object Util {
 
   object AlgFunctor {
 
-    def apply[Alg[_[_], _]](implicit ev: AlgFunctor[Alg]): AlgFunctor[Alg] = ev
+    def apply[Alg[_[_], _]](implicit ev: AlgFunctor[Alg]): AlgFunctor[Alg] = 
+      ev
 
     // XXX: boilerplate instances, consider using Shapeless here?
     
@@ -195,10 +196,15 @@ object Util {
         rInstance: Lazy[GetEvidence[R]]): GetEvidence[A] =
       GetEvidence[A](generic.from(rInstance.value.apply))
   
-    implicit def genericGetEvidence2[K, A, R](implicit
-        generic: LabelledGeneric.Aux[A, R],
-        rInstance: Lazy[GetEvidence[R]]): GetEvidence[FieldType[K, A]] =
-      GetEvidence[FieldType[K, A]](field[K](genericGetEvidence[A, R].apply)),
+    implicit def genericGetEvidence3[K, Alg[_[_], _], P[_], Q[_], S, R](implicit
+        algf: AlgFunctor[Alg],
+        nat: FieldType[K, Q ~> P],
+        f0: Functor[Q],
+        f1: Functor[P],
+        generic: LabelledGeneric.Aux[Alg[Q, S], R],
+        rInstance: Lazy[GetEvidence[R]]): GetEvidence[FieldType[K, Alg[P, S]]] =
+      GetEvidence(field[K](algf.amap(nat)(f0, f1)(
+        genericGetEvidence[Alg[Q, S], R].apply)))
   }
 }
  

--- a/src/main/scala/Core.scala
+++ b/src/main/scala/Core.scala
@@ -96,6 +96,10 @@ object Util {
       }
   }
  
+  implicit class LensOps[S, A](ln: monocle.Lens[S, A]) {
+    val natural: Lens[S, A] = Lens(ln.get, ln.set)
+  }
+
   def lensId[S]: Lens[S, S] = NaturalTransformation.refl
   
   implicit def self[A] = 'self ->> lensId[A]

--- a/src/main/scala/Core.scala
+++ b/src/main/scala/Core.scala
@@ -2,7 +2,7 @@ package org.hablapps.statesome
 
 import Function.const
 import scalaz._, Scalaz._
-import shapeless._, labelled._
+import shapeless._, shapeless.syntax.singleton._, labelled._
 
 /**
  * State algebras
@@ -97,6 +97,8 @@ object Util {
   }
  
   def lensId[S]: Lens[S, S] = NaturalTransformation.refl
+  
+  implicit def self[A] = 'self ->> lensId[A]
   
   implicit def compNat[P[_], Q[_], R[_]](implicit
       nat1: Q ~> P, 
@@ -196,7 +198,7 @@ object Util {
         rInstance: Lazy[GetEvidence[R]]): GetEvidence[A] =
       GetEvidence[A](generic.from(rInstance.value.apply))
   
-    implicit def genericGetEvidence3[K, Alg[_[_], _], P[_], Q[_], S, R](implicit
+    implicit def genericGetEvidence2[K, Alg[_[_], _], P[_], Q[_], S, R](implicit
         algf: AlgFunctor[Alg],
         nat: FieldType[K, Q ~> P],
         f0: Functor[Q],

--- a/src/test/scala/University.scala
+++ b/src/test/scala/University.scala
@@ -98,31 +98,40 @@ case class Logic[P[_], C, U, D](city: City[U, D, P, C]) {
 case class SCity(population: Int, univ: SUniversity)
 
 object SCity {
- 
+
+  implicit val selfLn =
+    'self ->> lensId[SCity]
+
   implicit val popuLn =
-    Lens[SCity, Int](_.population, p => _.copy(population = p))
+    'popu ->> Lens[SCity, Int](_.population, p => _.copy(population = p))
 
   implicit val univLn =
-    Lens[SCity, SUniversity](_.univ, u => _.copy(univ = u))
+    'univ ->> Lens[SCity, SUniversity](_.univ, u => _.copy(univ = u))
 }
 
 case class SUniversity(name: String, math: SDepartment)
 
 object SUniversity {
 
+  implicit val selfLn =
+    'self ->> lensId[SUniversity]
+
   implicit val nameLn =
-    Lens[SUniversity, String](_.name, n => _.copy(name = n))
+    'name ->> Lens[SUniversity, String](_.name, n => _.copy(name = n))
   
   implicit val mathLn =
-    Lens[SUniversity, SDepartment](_.math, d => _.copy(math = d))
+    'math ->> Lens[SUniversity, SDepartment](_.math, d => _.copy(math = d))
 }
 
 case class SDepartment(budget: Int)
 
 object SDepartment {
 
+  implicit val selfLn =
+    'self ->> lensId[SDepartment]
+
   implicit val budgetLn = 
-    Lens[SDepartment, Int](_.budget, b => _.copy(budget = b))
+    'budget ->> Lens[SDepartment, Int](_.budget, b => _.copy(budget = b))
 }
 
 import SCity._, SUniversity._, SDepartment._
@@ -133,17 +142,8 @@ class UniversitySpec extends FlatSpec with Matchers {
 
   "Automagic instances" should "be generated for city" in {
 
-    implicit val self = 'self ->> lensId[SCity]
-    implicit val popu = 'popu ->> popuLn
-    implicit val univ = 'univ ->> univLn
-    implicit val sel1 = 'self ->> (univ compose lensId[SUniversity])
-    implicit val name = 'name ->> (univ compose nameLn)
-    implicit val math = 'math ->> (univ compose mathLn)
-    implicit val sel2 = 'self ->> (math compose lensId[SDepartment])
-    implicit val budg = 'budget ->> (math compose budgetLn)
-
-    val StateCity = 
-      City.instance[State[SCity, ?], SCity, SUniversity, SDepartment]
+     val StateCity = 
+       City.instance[State[SCity, ?], SCity, SUniversity, SDepartment]
   
      val logic = Logic(StateCity)
     
@@ -161,20 +161,11 @@ class UniversitySpec extends FlatSpec with Matchers {
 
   it should "be generated for department" in {
     
-    implicit val self = 'self ->> lensId[SDepartment]
-    implicit val budg = 'budget ->> budgetLn
-
     val StateDepartment =
       Department.instance[State[SDepartment, ?], SDepartment]
   }
   
   it should "be generated for university" in {
-
-    implicit val sel1 = 'self ->> lensId[SUniversity]
-    implicit val name = 'name ->> nameLn
-    implicit val matx = 'math ->> mathLn
-    implicit val sel2 = 'self ->> (mathLn compose lensId[SDepartment])
-    implicit val budg = 'budget ->> (mathLn compose budgetLn)
 
     val StateUniversity = 
       University.instance[State[SUniversity, ?], SUniversity, SDepartment]

--- a/src/test/scala/University.scala
+++ b/src/test/scala/University.scala
@@ -3,7 +3,7 @@ package test
 package university
 
 import scalaz._
-import shapeless._, shapeless.syntax.singleton._, labelled._
+import shapeless._, shapeless.syntax.singleton._
 
 import Util.{ Lens, _ }, AlgFunctor._, GetEvidence._
 
@@ -125,13 +125,12 @@ object SDepartment {
     'budget ->> Lens[SDepartment, Int](_.budget, b => _.copy(budget = b))
 }
 
+import Util.self
 import SCity._, SUniversity._, SDepartment._
 
 import org.scalatest._
 
 class UniversitySpec extends FlatSpec with Matchers {
-
-  implicit def self[A] = 'self ->> lensId[A]
 
   "Automagic instances" should "be generated for city" in {
 

--- a/src/test/scala/University.scala
+++ b/src/test/scala/University.scala
@@ -99,9 +99,6 @@ case class SCity(population: Int, univ: SUniversity)
 
 object SCity {
 
-  implicit val selfLn =
-    'self ->> lensId[SCity]
-
   implicit val popuLn =
     'popu ->> Lens[SCity, Int](_.population, p => _.copy(population = p))
 
@@ -112,9 +109,6 @@ object SCity {
 case class SUniversity(name: String, math: SDepartment)
 
 object SUniversity {
-
-  implicit val selfLn =
-    'self ->> lensId[SUniversity]
 
   implicit val nameLn =
     'name ->> Lens[SUniversity, String](_.name, n => _.copy(name = n))
@@ -127,9 +121,6 @@ case class SDepartment(budget: Int)
 
 object SDepartment {
 
-  implicit val selfLn =
-    'self ->> lensId[SDepartment]
-
   implicit val budgetLn = 
     'budget ->> Lens[SDepartment, Int](_.budget, b => _.copy(budget = b))
 }
@@ -139,6 +130,8 @@ import SCity._, SUniversity._, SDepartment._
 import org.scalatest._
 
 class UniversitySpec extends FlatSpec with Matchers {
+
+  implicit def self[A] = 'self ->> lensId[A]
 
   "Automagic instances" should "be generated for city" in {
 

--- a/src/test/scala/University.scala
+++ b/src/test/scala/University.scala
@@ -3,10 +3,10 @@ package test
 package university
 
 import scalaz._
-import shapeless._, shapeless.syntax.singleton._
+import shapeless.syntax.singleton._
 import monocle.macros.Lenses
 
-import Util.{ Lens, _ }, AlgFunctor._, GetEvidence._
+import Util._, AlgFunctor._, GetEvidence._
 
 /**
  * Data Model
@@ -106,12 +106,11 @@ import org.scalatest._
 
 class UniversitySpec extends FlatSpec with Matchers {
 
-  // Map between fields and lenses: this is all we need!
-  implicit val popuLn = 'popu ->> population.natural
-  implicit val univLn = 'univ ->> univ.natural
-  implicit val nameLn = 'name ->> name.natural
-  implicit val mathLn = 'math ->> math.natural 
-  implicit val budgLn = 'budget ->> budget.natural
+  implicit val popuLn = 'popu ->> population
+  implicit val univLn = 'univ ->> univ
+  implicit val nameLn = 'name ->> name
+  implicit val mathLn = 'math ->> math 
+  implicit val budgLn = 'budget ->> budget
 
   "Automagic instances" should "be generated for city" in {
   


### PR DESCRIPTION
This contribution provides several improvements in regard with #2.
* The programmer isn't responsible for composing lenses any more, since this composition is achieved automatically in the shadows.
* The programmer has to provide the mapping between data layer names and lenses. But he does it once and for all, because it serves to instantiate any case class in the hierarchy.

However, this version requires instances of `AlgFunctor` for each algebra (case class). In fact, this mixes somehow the two tree approaches that we were considering at the beginning of this task to automate instances.