### PR TITLE
Generate optic evidences automatically

### DIFF
--- a/src/main/scala/Core.scala
+++ b/src/main/scala/Core.scala
@@ -226,8 +226,7 @@ object Util {
 
     implicit def genericTaggedLens[C, R, K, A](implicit
         generic: LabelledGeneric.Aux[C, R],
-        rInstance: Lazy[TaggedLens[K, R, A]])
-        : TaggedLens[K, C, A] =
+        rInstance: Lazy[TaggedLens[K, R, A]]): TaggedLens[K, C, A] =
       rInstance.value.getTaggedLens |> (ln => TaggedLens(field[K](Lens[C, A](
         c => ln(State.get).eval(generic.to(c)),
         a2 => c => generic.from(ln(State.put(a2)).exec(generic.to(c)))))))

--- a/src/main/scala/Core.scala
+++ b/src/main/scala/Core.scala
@@ -2,7 +2,7 @@ package org.hablapps.statesome
 
 import Function.const
 import scalaz._, Scalaz._
-import shapeless._, labelled._
+import shapeless._, shapeless.syntax.singleton._, labelled._
 
 /**
  * State algebras
@@ -152,14 +152,6 @@ object Util {
         }
     }
 
-    // implicit def ListPAlgFunctor[Alg[_[_], _]: AlgFunctor] =
-    //   new AlgFunctor[ListP[Alg, ?[_], ?]] {
-    //     def amap[Q[_]: Functor, P[_]: Functor](f: Q ~> P) =
-    //       λ[ListP[Alg, Q, ?] ~> ListP[Alg, P, ?]] { alg =>
-    //         ListP(f(alg.algs.map(_.map(_ amap f))))
-    //       }
-    //   }
-    
     implicit class AlgFunctorOps[Alg[_[_], _], Q[_]: Functor, A](
         al: Alg[Q, A]) {
       def amap[P[_]: Functor](f: Q ~> P)(implicit AF: AlgFunctor[Alg]) = 
@@ -215,6 +207,10 @@ object Util {
     implicit def hcons[K, H, T <: HList]: TaggedLens[K, FieldType[K, H] :: T, H] =
       TaggedLens(field[K](Lens[FieldType[K, H] :: T, H](
         _.head, h2 => field[K](h2) :: _.tail)))
+
+    implicit def hcons1[K, H, T <: HList] =
+      TaggedLens('self ->> Lens[FieldType[K, H] :: T, H](
+        _.head, h2 => field[K](h2) :: _.tail))
     
     implicit def hcons2[K, H, A, T <: HList](implicit
         ev: TaggedLens[K, T, A]): TaggedLens[K, H :: T, A] =

--- a/src/test/scala/University.scala
+++ b/src/test/scala/University.scala
@@ -3,8 +3,6 @@ package test
 package university
 
 import scalaz._
-import shapeless.syntax.singleton._
-import monocle.macros.Lenses
 
 import Util._, AlgFunctor._, GetEvidence._
 
@@ -96,40 +94,32 @@ case class Logic[P[_], C, U, D](city: City[U, D, P, C]) {
  * Data Layer Interpretation
  */
 
-@Lenses case class SCity(population: Int, univ: SUniversity)
-@Lenses case class SUniversity(name: String, math: SDepartment)
-@Lenses case class SDepartment(budget: Int)
-
-import SCity._, SUniversity._, SDepartment._
+case class SCity(popu: Int, univ: SUniversity)
+case class SUniversity(name: String, math: SDepartment)
+case class SDepartment(budget: Int)
 
 import org.scalatest._
 
 class UniversitySpec extends FlatSpec with Matchers {
 
-  implicit val popuLn = 'popu ->> population
-  implicit val univLn = 'univ ->> univ
-  implicit val nameLn = 'name ->> name
-  implicit val mathLn = 'math ->> math 
-  implicit val budgLn = 'budget ->> budget
+  // "Automagic instances" should "be generated for city" in {
+  // 
+  //   val StateCity = 
+  //     City.instance[State[SCity, ?], SCity, SUniversity, SDepartment]
+  // 
+  //   val logic = Logic(StateCity)
+  //   
+  //   val urjc = SUniversity("urjc", SDepartment(3000))
+  //   val most = SCity(200000, urjc)
 
-  "Automagic instances" should "be generated for city" in {
-  
-    val StateCity = 
-      City.instance[State[SCity, ?], SCity, SUniversity, SDepartment]
-  
-    val logic = Logic(StateCity)
-    
-    val urjc = SUniversity("urjc", SDepartment(3000))
-    val most = SCity(200000, urjc)
+  //   val popu2 = logic.getPopu.eval(most)
+  //   val most2 = logic.doubleBudget(implicitly).exec(most)
+  //   val math2 = logic.getMathDep.eval(most2)
 
-    val popu2 = logic.getPopu.eval(most)
-    val most2 = logic.doubleBudget(implicitly).exec(most)
-    val math2 = logic.getMathDep.eval(most2)
-
-    popu2 should be (200000)
-    most2 should be (SCity(200000, SUniversity("urjc", SDepartment(6000))))
-    math2 should be (SDepartment(6000))
-  }
+  //   popu2 should be (200000)
+  //   most2 should be (SCity(200000, SUniversity("urjc", SDepartment(6000))))
+  //   math2 should be (SDepartment(6000))
+  // }
 
   it should "be generated for department" in {
     Department.instance[State[SDepartment, ?], SDepartment]

--- a/src/test/scala/University.scala
+++ b/src/test/scala/University.scala
@@ -101,25 +101,33 @@ case class SDepartment(budget: Int)
 import org.scalatest._
 
 class UniversitySpec extends FlatSpec with Matchers {
+  
+  import shapeless.syntax.singleton._
 
-  // "Automagic instances" should "be generated for city" in {
-  // 
-  //   val StateCity = 
-  //     City.instance[State[SCity, ?], SCity, SUniversity, SDepartment]
-  // 
-  //   val logic = Logic(StateCity)
-  //   
-  //   val urjc = SUniversity("urjc", SDepartment(3000))
-  //   val most = SCity(200000, urjc)
+  implicit val mathLn = 'math ->> Util.Lens[SUniversity, SDepartment](
+    _.math, d2 => _.copy(math = d2))
 
-  //   val popu2 = logic.getPopu.eval(most)
-  //   val most2 = logic.doubleBudget(implicitly).exec(most)
-  //   val math2 = logic.getMathDep.eval(most2)
+  implicit val univLn = 'univ ->> Util.Lens[SCity, SUniversity](
+    _.univ, u2 => _.copy(univ = u2))
 
-  //   popu2 should be (200000)
-  //   most2 should be (SCity(200000, SUniversity("urjc", SDepartment(6000))))
-  //   math2 should be (SDepartment(6000))
-  // }
+  "Automagic instances" should "be generated for city" in {
+  
+    val StateCity = 
+      City.instance[State[SCity, ?], SCity, SUniversity, SDepartment]
+  
+    val logic = Logic(StateCity)
+    
+    val urjc = SUniversity("urjc", SDepartment(3000))
+    val most = SCity(200000, urjc)
+
+    val popu2 = logic.getPopu.eval(most)
+    val most2 = logic.doubleBudget(implicitly).exec(most)
+    val math2 = logic.getMathDep.eval(most2)
+
+    popu2 should be (200000)
+    most2 should be (SCity(200000, SUniversity("urjc", SDepartment(6000))))
+    math2 should be (SDepartment(6000))
+  }
 
   it should "be generated for department" in {
     Department.instance[State[SDepartment, ?], SDepartment]

--- a/src/test/scala/University.scala
+++ b/src/test/scala/University.scala
@@ -104,11 +104,11 @@ class UniversitySpec extends FlatSpec with Matchers {
   
   import shapeless.syntax.singleton._
 
-  implicit val self0 = 'self ->> Util.Lens[SCity, SUniversity](
-    _.univ, u2 => _.copy(univ = u2))
-  implicit val self1 = 'self ->> Util.Lens[SUniversity, SDepartment](
-    _.math, d2 => _.copy(math = d2)) 
-  implicit val self2 = 'self ->> (self0 compose self1)
+  // implicit val self0 = 'self ->> Util.Lens[SCity, SUniversity](
+  //   _.univ, u2 => _.copy(univ = u2))
+  // implicit val self1 = 'self ->> Util.Lens[SUniversity, SDepartment](
+  //   _.math, d2 => _.copy(math = d2)) 
+  // implicit val self2 = 'self ->> (self0 compose self1)
 
   "Automagic instances" should "be generated for city" in {
   

--- a/src/test/scala/University.scala
+++ b/src/test/scala/University.scala
@@ -104,11 +104,11 @@ class UniversitySpec extends FlatSpec with Matchers {
   
   import shapeless.syntax.singleton._
 
-  implicit val mathLn = 'math ->> Util.Lens[SUniversity, SDepartment](
-    _.math, d2 => _.copy(math = d2))
-
-  implicit val univLn = 'univ ->> Util.Lens[SCity, SUniversity](
+  implicit val self0 = 'self ->> Util.Lens[SCity, SUniversity](
     _.univ, u2 => _.copy(univ = u2))
+  implicit val self1 = 'self ->> Util.Lens[SUniversity, SDepartment](
+    _.math, d2 => _.copy(math = d2)) 
+  implicit val self2 = 'self ->> (self0 compose self1)
 
   "Automagic instances" should "be generated for city" in {
   


### PR DESCRIPTION
Manual optics evidences are no longer required.