### PR TITLE
Apply several optimizations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
 name := "statelesser"
 
-// scalaVersion := "2.12.4"
-
 organization := "org.hablapps"
 
 inThisBuild(Seq(

--- a/src/main/scala/GetEvidence.scala
+++ b/src/main/scala/GetEvidence.scala
@@ -2,8 +2,6 @@ package org.hablapps.statelesser
 
 import shapeless._, labelled._
 
-// Just a wrapper of values of type `A` which carries a phantom `Ctx`, that
-// represents the location of the value. 
 trait GetEvidence[Ctx <: HList, A] {
   def apply: A
 }
@@ -17,13 +15,9 @@ object GetEvidence {
   def apply[Ctx <: HList, A](a: A): GetEvidence[Ctx, A] =
     new GetEvidence[Ctx, A] { def apply = a }
 
-  // We can always get an evidence of `HNil`.
   implicit def emptyProduct[Ctx <: HList]: GetEvidence[Ctx, HNil] = 
     GetEvidence(HNil)
 
-  // Returns an evidence of `H :: T` by searching for an implicit evidende of
-  // `H` and recursing over `T`. While searching for the `H` evidence, the
-  // context is extended with the label, to keep track of the full context.
   implicit def product[Ctx <: HList, K, H, T <: HList](implicit
       hev: Lazy[GetEvidence[K :: Ctx, H]],
       tev: GetEvidence[Ctx, T]): GetEvidence[Ctx, FieldType[K, H] :: T] =
@@ -34,6 +28,5 @@ object GetEvidence {
       generic: LabelledGeneric.Aux[A, R],
       rInstance: Lazy[GetEvidence[Ctx, R]]): GetEvidence[Ctx, A] =
     GetEvidence(generic.from(rInstance.value.apply))
-
 }
 

--- a/src/main/scala/TaggedLens.scala
+++ b/src/main/scala/TaggedLens.scala
@@ -4,60 +4,50 @@ import scalaz._, Scalaz._
 import shapeless._, labelled._
 import Util.Lens
 
-// Provides a lens tagged with a context.
-trait TaggedLens[Ctx <: HList, S, A] {
-  val getTaggedLens: FieldType[Ctx, Lens[S, A]]
+trait Shapelens[S, Ctx <: HList] {
+  type A
+  val getLens: Lens[S, A]
 }
 
-object TaggedLens {
+object Shapelens {
 
-  def apply[Ctx <: HList, S, A](implicit 
-      tl: TaggedLens[Ctx, S, A]): TaggedLens[Ctx, S, A] = 
+  type Aux[S, Ctx <: HList, A2] = Shapelens[S, Ctx] { type A = A2 }
+  
+  def apply[S, Ctx <: HList](implicit 
+      tl: Shapelens[S, Ctx]): Aux[S, Ctx, tl.A] = 
     tl
 
-  def apply[Ctx <: HList, S, A](
-      ft: FieldType[Ctx, Lens[S, A]]): TaggedLens[Ctx, S, A] =
-    new TaggedLens[Ctx, S, A] { val getTaggedLens = ft }
+  def apply[S, Ctx <: HList, A2](ln: Lens[S, A2]): Aux[S, Ctx, A2] =
+    new Shapelens[S, Ctx] { type A = A2; val getLens = ln }
 
-  // Provides a lens pointing at the head of this `HList`, as long as the
-  // label of the head is compliant with the context, I mean, the label is
-  // the unique tag standing in the context list.
   implicit def productHead[K, H, T <: HList]
-      : TaggedLens[K :: HNil, FieldType[K, H] :: T, H] =
-    TaggedLens(field[K :: HNil](Lens[FieldType[K, H] :: T, H](
-      _.head, h2 => field[K](h2) :: _.tail)))
+      : Aux[FieldType[K, H] :: T, K :: HNil, H] =
+    apply(Lens[FieldType[K, H] :: T, H](
+      _.head, h2 => field[K](h2) :: _.tail))
 
-  // Ad hoc evidence to deal with `'self`s. The problem is that there's no
-  // attribute named `self` in the case class, but we need to fulfill it for
-  // the data layer. In fact, the lens that we are interested in for this
-  // case is the one that acts as nexus between classes. Thereby, we need to
-  // stop one step early, before searching for `'self`.  
-  implicit def productSelf[K, H, T <: HList] =
-    TaggedLens(field[K :: Witness.`'self`.T :: HNil](
-      Lens[FieldType[K, H] :: T, H](
-        _.head, h2 => field[K](h2) :: _.tail)))
+  implicit def productSelf[J, H, T <: HList]
+      : Aux[FieldType[J, H] :: T, J :: Witness.`'self`.T :: HNil, H] =
+    apply(Lens[FieldType[J, H] :: T, H](
+      _.head, h2 => field[J](h2) :: _.tail))
   
-  // Provides a lens that points at some component in the resulting tail.
-  implicit def productTail[Ctx <: HList, K, H, A, T <: HList](implicit
-      ev: TaggedLens[K :: Ctx, T, A]): TaggedLens[K :: Ctx, H :: T, A] =
-    TaggedLens(field[K :: Ctx](Lens[H :: T, A](
-      l => ev.getTaggedLens(State.get).eval(l.tail), 
-      a2 => l => l.head :: ev.getTaggedLens(State.put(a2)).exec(l.tail))))
+  implicit def productTail[Ctx <: HList, J, K: J =:!= ?, H, A, T <: HList](implicit
+      tl: Aux[T, K :: Ctx, A]): Aux[FieldType[J, H] :: T, K :: Ctx, A] =
+    apply(Lens[FieldType[J, H] :: T, A](
+      l => tl.getLens(State.get).eval(l.tail), 
+      a2 => l => l.head :: tl.getLens(State.put(a2)).exec(l.tail)))
 
-  // Provides a lens that points at a subcomponent of this head, which we can
-  // see as lens composition, since we are pointing at a nested value.
-  implicit def productDepth[Ctx <: HList, J, K, H, A, T <: HList](implicit
-      ev: TaggedLens[Ctx, H, A])
-      : TaggedLens[K :: Ctx, FieldType[J, H] :: T, A] =
-    ev.getTaggedLens |> (ln =>
-      TaggedLens(field[K :: Ctx](Lens[FieldType[J, H] :: T, A](
-        l => ln(State.get).eval(l.head),
-        a2 => l => field[J](ln(State.put(a2)).exec(l.head)) :: l.tail))))
+  implicit def productDepth[Ctx <: HList, K, H, A, T <: HList](implicit
+      tl: Aux[H, Ctx, A])
+      : Aux[FieldType[K, H] :: T, K :: Ctx, A] =
+    tl.getLens |> (ln => apply(Lens[FieldType[K, H] :: T, A](
+      l => ln(State.get).eval(l.head),
+      a2 => l => field[K](ln(State.put(a2)).exec(l.head)) :: l.tail)))
 
-  implicit def genericTaggedLens[C, R, Ctx <: HList, A](implicit
+  implicit def genericShapelens[C, R, Ctx <: HList, A](implicit
       generic: LabelledGeneric.Aux[C, R],
-      rInstance: Lazy[TaggedLens[Ctx, R, A]]): TaggedLens[Ctx, C, A] =
-    rInstance.value.getTaggedLens |> (ln => TaggedLens(field[Ctx](Lens[C, A](
+      rInstance: Lazy[Aux[R, Ctx, A]]): Aux[C, Ctx, A] =
+    rInstance.value.getLens |> (ln => apply(Lens[C, A](
       c => ln(State.get).eval(generic.to(c)),
-      a2 => c => generic.from(ln(State.put(a2)).exec(generic.to(c)))))))
+      a2 => c => generic.from(ln(State.put(a2)).exec(generic.to(c))))))
 }
+

--- a/src/test/scala/University.scala
+++ b/src/test/scala/University.scala
@@ -8,9 +8,7 @@ import org.scalatest._
 import Util._, GetEvidence._, Primitive._
 
 
-/*
- * Data Model
- */
+/* Data Model */
 
 case class City[P[_], C, U, D](
   self: Field[P, C],
@@ -28,9 +26,7 @@ case class Department[P[_],D](
   budget: IntegerP[P])
 
 
-/*
- * Logic
- */
+/* Logic */
 
 case class Logic[P[_], C, U, D](city: City[P, C, U, D]) {
 
@@ -49,9 +45,7 @@ case class Logic[P[_], C, U, D](city: City[P, C, U, D]) {
 }
 
 
-/*
- * Interpretation
- */
+/* Interpretation */
 
 case class SCity(popu: Int, name: String, univ: SUniversity)
 case class SUniversity(name: String, math: SDepartment)


### PR DESCRIPTION
Applies several optimizations, mainly this provides a guidance to the compiler, so the number of implicit searches has been reduced remarkably.