### PR TITLE
Introduce traversal

### DIFF
--- a/src/main/scala/LensAlgHom.scala
+++ b/src/main/scala/LensAlgHom.scala
@@ -6,14 +6,14 @@ import shapeless._
 trait LensAlgHom[Alg[_[_], _], P[_], A] {
   type Q[_]
   val alg: Alg[Q, A]
-  def apply(): Q ~> P
+  val hom: Q ~> P
 
   def fold[B](f: Alg[Q, A] => Q[B]): P[B] =
-    apply()(f(alg))
+    hom(f(alg))
 
   def composeLens[Alg2[_[_], _], B](
       ln: LensAlgHom[Alg2, Q, B]): LensAlgHom.Aux[Alg2, P, ln.Q, B] =
-    LensAlgHom[Alg2, P, ln.Q, B](ln.alg, apply() compose ln())
+    LensAlgHom[Alg2, P, ln.Q, B](ln.alg, hom compose ln.hom)
 }
 
 object LensAlgHom {
@@ -23,21 +23,21 @@ object LensAlgHom {
 
   def apply[Alg[_[_], _], P[_], Q2[_], A](
       alg2: Alg[Q2, A],
-      app2: Q2 ~> P): Aux[Alg, P, Q2, A] =
+      hom2: Q2 ~> P): Aux[Alg, P, Q2, A] =
     new LensAlgHom[Alg, P, A] {
       type Q[x] = Q2[x]
       val alg = alg2
-      def apply() = app2
+      val hom = hom2
     }
 
   implicit def genLensAlgHom[H, T <: HList, Alg[_[_], _], S, A](implicit 
       ge: GetEvidence[HNil, Alg[State[A, ?], A]],
-      dl: MkFieldLens.Aux[S, H, A])
+      fl: MkFieldLens.Aux[S, H, A])
       : GetEvidence[H :: T, LensAlgHom[Alg, State[S, ?], A]] =
-    GetEvidence(LensAlgHom(ge(), dl()))
+    GetEvidence(LensAlgHom(ge(), fl()))
 
   trait Syntax {
-    implicit class LensSyntax[P[_], A](la: LensAlg[P, A]) {
+    implicit class LensAlgSyntax[P[_], A](la: LensAlg[P, A]) {
       def get: P[A] = la.fold(_.get)
       def set(a: A): P[Unit] = la.fold(_.put(a))
       def modify(f: A => A): P[Unit] = la.fold(_.modify(f))

--- a/src/main/scala/LensAlgHom.scala
+++ b/src/main/scala/LensAlgHom.scala
@@ -14,6 +14,11 @@ trait LensAlgHom[Alg[_[_], _], P[_], A] {
   def composeLens[Alg2[_[_], _], B](
       ln: LensAlgHom[Alg2, Q, B]): LensAlgHom.Aux[Alg2, P, ln.Q, B] =
     LensAlgHom[Alg2, P, ln.Q, B](ln.alg, hom compose ln.hom)
+
+  def composeTraversal[Alg2[_[_], _], B](
+      tr: TraversalAlgHom[Alg2, Q, B]): TraversalAlgHom.Aux[Alg2, P, tr.Q, B] =
+    TraversalAlgHom[Alg2, P, tr.Q, B](tr.alg, 
+      λ[ListT[Q, ?] ~> ListT[P, ?]](ltq => ListT(hom(ltq.run))) compose tr.hom)
 }
 
 object LensAlgHom {

--- a/src/main/scala/TraversalAlgHom.scala
+++ b/src/main/scala/TraversalAlgHom.scala
@@ -1,0 +1,47 @@
+package org.hablapps.statelesser
+
+import scalaz._, Scalaz._
+
+trait TraversalAlgHom[Alg[_[_], _], P[_], A] {
+  type Q[_]
+  val alg: Alg[Q, A]
+  val hom: Q ~> ListT[P, ?]
+
+  def apply[B](f: Alg[Q, A] => Q[B]): P[List[B]] =
+    hom(f(alg)).run
+
+  def fold[B](f: Alg[Q, A] => Q[B])(implicit 
+      F: Functor[P],
+      M: Monoid[B]): P[B] =
+    apply(f).map(_.suml)
+
+  def composeLens[Alg2[_[_], _], B](
+      ln: LensAlgHom[Alg2, Q, B]): TraversalAlgHom.Aux[Alg2, P, ln.Q, B] =
+    TraversalAlgHom[Alg2, P, ln.Q, B](ln.alg, hom compose ln.hom)
+}
+
+object TraversalAlgHom {
+
+  type Aux[Alg[_[_], _], P[_], Q2[_], A] = 
+    TraversalAlgHom[Alg, P, A] { type Q[x] = Q2[x] }
+
+  def apply[Alg[_[_], _], P[_], Q2[_], A](
+      alg2: Alg[Q2, A],
+      hom2: Q2 ~> ListT[P, ?]): Aux[Alg, P, Q2, A] =
+    new TraversalAlgHom[Alg, P, A] {
+      type Q[x] = Q2[x]
+      val alg = alg2
+      val hom = hom2
+    }
+
+  trait Syntax {
+    implicit class Syntax[P[_], A](ta: TraversalAlg[P, A]) {
+      def foldMap[B: Monoid](f: A => B)(implicit F: Functor[P]): P[B] = 
+        ta.fold(_.gets(f))
+      def modify(f: A => A)(implicit F: Functor[P]): P[Unit] = 
+        ta(_.modify(f)).void
+      def getAll: P[List[A]] = ta(_.get)
+    }
+  }
+}
+

--- a/src/main/scala/TraversalAlgHom.scala
+++ b/src/main/scala/TraversalAlgHom.scala
@@ -19,6 +19,13 @@ trait TraversalAlgHom[Alg[_[_], _], P[_], A] {
   def composeLens[Alg2[_[_], _], B](
       ln: LensAlgHom[Alg2, Q, B]): TraversalAlgHom.Aux[Alg2, P, ln.Q, B] =
     TraversalAlgHom[Alg2, P, ln.Q, B](ln.alg, hom compose ln.hom)
+
+  def composeTraversal[Alg2[_[_], _], B](
+      tr: TraversalAlgHom[Alg2, Q, B])(implicit
+      F: Functor[P]): TraversalAlgHom.Aux[Alg2, P, tr.Q, B] =
+    TraversalAlgHom[Alg2, P, tr.Q, B](tr.alg, 
+      λ[ListT[Q, ?] ~> ListT[P, ?]](ltq => ListT(hom(ltq.run).run.map(_.join))) 
+        compose tr.hom)
 }
 
 object TraversalAlgHom {

--- a/src/main/scala/TraversalAlgHom.scala
+++ b/src/main/scala/TraversalAlgHom.scala
@@ -1,6 +1,7 @@
 package org.hablapps.statelesser
 
 import scalaz._, Scalaz._
+import shapeless._
 
 trait TraversalAlgHom[Alg[_[_], _], P[_], A] {
   type Q[_]
@@ -33,6 +34,12 @@ object TraversalAlgHom {
       val alg = alg2
       val hom = hom2
     }
+
+  implicit def genTraversalAlgHom[H, T <: HList, Alg[_[_], _], S, A](implicit 
+      ge: GetEvidence[HNil, Alg[State[A, ?], A]],
+      fl: MkFieldLens.Aux[S, H, List[A]])
+      : GetEvidence[H :: T, TraversalAlgHom[Alg, State[S, ?], A]] =
+    GetEvidence(TraversalAlgHom(ge(), fl()))
 
   trait Syntax {
     implicit class Syntax[P[_], A](ta: TraversalAlg[P, A]) {

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -3,7 +3,8 @@ package org.hablapps
 import scalaz._, Scalaz._
 import shapeless._
 
-package object statelesser extends LensAlgHom.Syntax {
+package object statelesser extends LensAlgHom.Syntax
+    with TraversalAlgHom.Syntax {
 
   type LensAlg[P[_], A] = LensAlgHom[MonadState, P, A]
 
@@ -12,6 +13,14 @@ package object statelesser extends LensAlgHom.Syntax {
       LensAlgHom[MonadState, P, State[A, ?], A](implicitly, hom)
   }
 
+  type TraversalAlg[P[_], A] = 
+    TraversalAlgHom.Aux[MonadState, P, State[A, ?], A]
+
+  object TraversalAlg {
+    def apply[P[_], A](hom: State[A, ?] ~> ListT[P, ?]): TraversalAlg[P, A] =
+      TraversalAlgHom[MonadState, P, State[A, ?], A](implicitly, hom)
+  }
+  
   implicit def slensToLens[S, A](
       ln: shapeless.Lens[S, A]): naturally.Lens[S, A] =
     λ[State[A, ?] ~> State[S, ?]] { sa => 

--- a/src/test/scala/University.scala
+++ b/src/test/scala/University.scala
@@ -4,7 +4,7 @@ package statelesser
 package test
 package university
 
-import scalaz._
+import scalaz._, Scalaz._
 import org.scalatest._
 import GetEvidence._
 
@@ -96,6 +96,24 @@ class UniversitySpec extends FlatSpec with Matchers {
         urjc.dep.copy(boss = 
           urjc.dep.boss.copy(last = 
             urjc.dep.boss.last.toUpperCase)))
+  }
+
+  it should "be generated for an algebra with a n-ary field" in {
+    
+    case class Person[P[_], Per: MonadState[P, ?]](
+      nicks: TraversalAlg[P, String])
+
+    case class SPerson(nicks: List[String])
+    val cristina = SPerson(List("cifu", "presi", "cris"))
+
+    val personState = make[Person[State[SPerson, ?], SPerson]]
+
+    val getNicks = personState.nicks.getAll
+    val upcNicks = personState.nicks.modify(_.toUpperCase)
+
+    getNicks(cristina) shouldBe ((cristina, cristina.nicks))
+    upcNicks.exec(cristina) shouldBe 
+      cristina.copy(nicks = cristina.nicks.map(_.toUpperCase))
   }
 }
 

--- a/src/test/scala/University.scala
+++ b/src/test/scala/University.scala
@@ -19,7 +19,7 @@ class UniversitySpec extends FlatSpec with Matchers {
   case class SUniversity(dep: SDepartment)
   val urjc = SUniversity(math)
 
-  "Automagic instances" should "be generated for a one-field algebra" in {
+  "Automagic instance" should "be generated for a one-field algebra" in {
 
     case class Person[P[_], Per: MonadState[P, ?]](last: LensAlg[P, String])
 
@@ -114,6 +114,97 @@ class UniversitySpec extends FlatSpec with Matchers {
     getNicks(cristina) shouldBe ((cristina, cristina.nicks))
     upcNicks.exec(cristina) shouldBe 
       cristina.copy(nicks = cristina.nicks.map(_.toUpperCase))
+  }
+
+  it should "be generated for an algebra with mixed fields" in {
+    
+    case class Person[P[_], Per: MonadState[P, ?]](
+      last: LensAlg[P, String],
+      nicks: TraversalAlg[P, String])
+
+    case class SPerson(last: String, nicks: List[String])
+    val cris = SPerson("cifuentes", List("cifu", "presi", "cris"))
+
+    val personState = make[Person[State[SPerson, ?], SPerson]]
+
+    val getLast = personState.last.get
+    val upcLast = personState.last.modify(_.toUpperCase)
+    val getNicks = personState.nicks.getAll
+    val upcNicks = personState.nicks.modify(_.toUpperCase)
+
+    getLast(cris) shouldBe ((cris, cris.last))
+    upcLast.exec(cris) shouldBe cris.copy(last = cris.last.toUpperCase)
+    getNicks(cris) shouldBe ((cris, cris.nicks))
+    upcNicks.exec(cris) shouldBe 
+      cris.copy(nicks = cris.nicks.map(_.toUpperCase))
+  }
+
+
+  it should "be generated for an algebra with a nested n-ary field" in {
+    
+    case class Department[Per, P[_], Dep: MonadState[P, ?]](
+      budget: LensAlg[P, Int],
+      bosses: TraversalAlgHom[Person, P, Per])
+
+    case class Person[P[_], Per: MonadState[P, ?]](
+      last: LensAlg[P, String])
+
+    case class SDepartment(budget: Int, bosses: List[SPerson])
+    case class SPerson(last: String)
+    val cris = SPerson("cifuentes")
+    val john = SPerson("doe")
+    val math = SDepartment(100000, List(cris, john))
+
+    val departmentState = 
+      make[Department[SPerson, State[SDepartment, ?], SDepartment]]
+    import departmentState._, bosses.alg._
+
+    val bossLasts = bosses composeLens last
+    val getLasts = bossLasts.getAll
+    val upcLasts = bossLasts.modify(_.toUpperCase)
+
+    getLasts(math) shouldBe ((math, math.bosses.map(_.last)))
+    upcLasts.exec(math) shouldBe
+      math.copy(bosses = math.bosses.map(p => p.copy(last = p.last.toUpperCase)))
+  }
+
+  it should "be generated for a complex data layer" in {
+
+    case class University[Dep, Per, P[_], Univ: MonadState[P, ?]](
+      deps: TraversalAlgHom[Department[Per, ?[_], ?], P, Dep])
+
+    case class Department[Per, P[_], Dep: MonadState[P, ?]](
+      budget: LensAlg[P, Int],
+      boss: LensAlgHom[Person, P, Per])
+
+    case class Person[P[_], Per: MonadState[P, ?]](
+      first: LensAlg[P, String],
+      last:  LensAlg[P, String])
+
+    case class SPerson(first: String, last: String)
+    val john = SPerson("john", "doe")
+    val cris = SPerson("cristina", "cifuentes")
+
+    case class SDepartment(budget: Int, boss: SPerson)
+    val cs = SDepartment(150000, cris)
+    val math = SDepartment(100000, john)
+
+    case class SUniversity(deps: List[SDepartment])
+    val urjc = SUniversity(List(cs, math))
+
+    val universityState = 
+      make[University[SDepartment, SPerson, State[SUniversity, ?], SUniversity]]
+    import universityState._, deps.alg._, boss.alg._
+
+    val univBossLasts = deps composeLens boss composeLens last
+    val getUnivBossLasts = univBossLasts.getAll
+    val ucUnivBossLasts = univBossLasts.modify(_.toUpperCase)
+
+    getUnivBossLasts(urjc) shouldBe ((urjc, urjc.deps.map(_.boss.last)))
+    ucUnivBossLasts.exec(urjc) shouldBe
+      urjc.copy(deps =
+        urjc.deps.map(d => d.copy(boss =
+          d.boss.copy(last = d.boss.last.toUpperCase))))
   }
 }
 


### PR DESCRIPTION
Here, we introduce `TraversalAlgHom` as an alternative optic algebra to describe n-ary fields. The automatic instantiation is working fine, though there are still several details that should be generalized.