### PR TITLE
Adds InitialSAlg and MonadState selectors

### DIFF
--- a/src/main/scala/InitialAlg.scala
+++ b/src/main/scala/InitialAlg.scala
@@ -13,6 +13,11 @@ object InitialSAlg {
       def apply[Q[_]](alg: MonadState[Q, A]) = alg.get
     }
 
+  def getsMS[A, B](f: A => B): InitialSAlg[MonadState, A, B] =
+    new InitialSAlg[MonadState, A, B] {
+      def apply[Q[_]](alg: MonadState[Q, A]) = alg.gets(f)
+    }
+
   def putMS[A](a: A): InitialSAlg[MonadState, A, Unit] =
     new InitialSAlg[MonadState, A, Unit] {
       def apply[Q[_]](alg: MonadState[Q, A]) = alg.put(a)

--- a/src/main/scala/InitialAlg.scala
+++ b/src/main/scala/InitialAlg.scala
@@ -1,0 +1,26 @@
+package org.hablapps.statelesser
+
+import scalaz.MonadState
+
+trait InitialSAlg[Alg[_[_], _], A, X] {
+  def apply[Q[_]](alg: Alg[Q, A]): Q[X]
+}
+
+object InitialSAlg {
+
+  def getMS[A]: InitialSAlg[MonadState, A, A] =
+    new InitialSAlg[MonadState, A, A] {
+      def apply[Q[_]](alg: MonadState[Q, A]) = alg.get
+    }
+
+  def putMS[A](a: A): InitialSAlg[MonadState, A, Unit] =
+    new InitialSAlg[MonadState, A, Unit] {
+      def apply[Q[_]](alg: MonadState[Q, A]) = alg.put(a)
+    }
+
+  def modMS[A](f: A => A): InitialSAlg[MonadState, A, Unit] =
+    new InitialSAlg[MonadState, A, Unit] {
+      def apply[Q[_]](alg: MonadState[Q, A]) = alg.modify(f)
+    }
+}
+

--- a/src/main/scala/LensAlgHom.scala
+++ b/src/main/scala/LensAlgHom.scala
@@ -8,7 +8,7 @@ trait LensAlgHom[Alg[_[_], _], P[_], A] {
   val alg: Alg[Q, A]
   val hom: Q ~> P
 
-  def fold[B](f: Alg[Q, A] => Q[B]): P[B] =
+  def fold[B](f: InitialSAlg[Alg, A, B]): P[B] =
     hom(f(alg))
 
   def composeLens[Alg2[_[_], _], B](
@@ -41,11 +41,13 @@ object LensAlgHom {
       : GetEvidence[H :: T, LensAlgHom[Alg, State[S, ?], A]] =
     GetEvidence(LensAlgHom(ge(), fl()))
 
+  import InitialSAlg._
+
   trait Syntax {
     implicit class LensAlgSyntax[P[_], A](la: LensAlg[P, A]) {
-      def get: P[A] = la.fold(_.get)
-      def set(a: A): P[Unit] = la.fold(_.put(a))
-      def modify(f: A => A): P[Unit] = la.fold(_.modify(f))
+      def get: P[A] = la.fold(getMS)
+      def set(a: A): P[Unit] = la.fold(putMS(a))
+      def modify(f: A => A): P[Unit] = la.fold(modMS(f))
     }
   }
 }

--- a/src/main/scala/LensAlgHom.scala
+++ b/src/main/scala/LensAlgHom.scala
@@ -8,7 +8,7 @@ trait LensAlgHom[Alg[_[_], _], P[_], A] {
   val alg: Alg[Q, A]
   val hom: Q ~> P
 
-  def fold[B](f: InitialSAlg[Alg, A, B]): P[B] =
+  def apply[B](f: InitialSAlg[Alg, A, B]): P[B] =
     hom(f(alg))
 
   def composeLens[Alg2[_[_], _], B](
@@ -45,9 +45,9 @@ object LensAlgHom {
 
   trait Syntax {
     implicit class LensAlgSyntax[P[_], A](la: LensAlg[P, A]) {
-      def get: P[A] = la.fold(getMS)
-      def set(a: A): P[Unit] = la.fold(putMS(a))
-      def modify(f: A => A): P[Unit] = la.fold(modMS(f))
+      def get: P[A] = la(getMS)
+      def set(a: A): P[Unit] = la(putMS(a))
+      def modify(f: A => A): P[Unit] = la(modMS(f))
     }
   }
 }

--- a/src/main/scala/TraversalAlgHom.scala
+++ b/src/main/scala/TraversalAlgHom.scala
@@ -8,10 +8,10 @@ trait TraversalAlgHom[Alg[_[_], _], P[_], A] {
   val alg: Alg[Q, A]
   val hom: Q ~> ListT[P, ?]
 
-  def apply[B](f: Alg[Q, A] => Q[B]): P[List[B]] =
+  def apply[B](f: InitialSAlg[Alg, A, B]): P[List[B]] =
     hom(f(alg)).run
 
-  def fold[B](f: Alg[Q, A] => Q[B])(implicit 
+  def fold[B](f: InitialSAlg[Alg, A, B])(implicit 
       F: Functor[P],
       M: Monoid[B]): P[B] =
     apply(f).map(_.suml)
@@ -48,13 +48,15 @@ object TraversalAlgHom {
       : GetEvidence[H :: T, TraversalAlgHom[Alg, State[S, ?], A]] =
     GetEvidence(TraversalAlgHom(ge(), fl()))
 
+  import InitialSAlg._
+
   trait Syntax {
     implicit class Syntax[P[_], A](ta: TraversalAlg[P, A]) {
       def foldMap[B: Monoid](f: A => B)(implicit F: Functor[P]): P[B] = 
-        ta.fold(_.gets(f))
+        ta.fold(getsMS(f))
       def modify(f: A => A)(implicit F: Functor[P]): P[Unit] = 
-        ta(_.modify(f)).void
-      def getAll: P[List[A]] = ta(_.get)
+        ta(modMS(f)).void
+      def getAll: P[List[A]] = ta(getMS)
     }
   }
 }


### PR DESCRIPTION
# Free and Lens Alg Notes

Our lens algebra is defined as follows:

```scala
trait LensAlgHom[Alg[_[_], _], P[_], A] {
  type Q[_]
  val alg: Alg[Q, A]
  val hom: Q ~> P
}
``` 
However, we found that a new derived method could be convenient:

```scala
def apply[X](sel: Selector[Alg, A, X]): P[X]
```

We can adopt it to reuse the same program among invocations to different lens
algebras. Juanma noticed that this definition was really close to the one from
Free Monads, so we wondered if we could use it as a primitive to replace alg and
hom. On the other hand the abstraction `state A ~> P` is also really close from
this definition. Although we haven't been successful with our goals, we have
learn several things that we want to collect here.


## Selector as a Free Algebra

Guided by a pragmatic approach I ended up defining `Selector` as follows:

```scala
trait Selector[Alg[_[_], _], A, X] {
  def apply[Q[_]](Alg[Q, A]): Q[X]
}
```

where I was trying to be able to select a method from the algebra for any
particular interpretation Q. This is pretty similar to the way we encode Free
Algebras. In fact, Free is a functor that knows how to enrich objects from a
simple category into another one which deploys a richer structure. For example,
the Free monoid (List) knows how to map objects from the Set category into
objects of the Monoid category. We can encode Free using Church Encoding with an
additional function to embed the members of the generator set:

```scala
trait FreeMonoid[A] {
  def apply[B](e: A => B, Monoid[B]): B
}
```

If we abstract away Monoid-specific stuff, we get the following definition:

```scala
trait FreeAlgebra[Alg[_], A] {
  def apply[B](e: A => B, Alg[B]): B
}
```

Now we are getting closer to the original `Selector`. The major difference is
that the latter is parameterized over type constructors. So, we can adapt the
Monoid example to Monads as next step:

```scala
trait FreeMonad[F[_], A] {
  def apply[G[_]](e: F ~> G, Monad[G]): G[A]
}
```

Notice that our generator F is now a type constructor. We need an additional
parameter A, since `FreeMonad[F, ?]` should be a valid Monad as well. Besides,
our embedding function becomes a natural transformation. Again, we can abstract
away Monad-specific stuff:

```scala
trait FreeHAlg[Alg[_[_]], F[_], A] {
  def apply[G[_]](e: F ~> G, Alg[G]): G[A]
}
```

This definition is pretty similar to our original Selector. The major
differences are the existence of an embedding function and the shape of the
Alg parameter, which doesn't require an additional parameter (since it's not a
state algebra).

So, can we replace Selector by FreeHAlg in the apply derived method and use it
as the only required primitive for lens algebras? Not really, but we will
provide some theory to support the hypothesis.

If we pay attention to the resulting apply method:

```scala
def apply[X](sel: FreeAlg[Alg[?[_], A], Q, X]): P[X]
```

it is telling us that it knows how to turn a FreeAlg into a program P, so it
is hiding an interpretation (or foldMap) from FreeAlg to P. As Juanma saw, this
is very similar to a T-algebra (or monad algebra):

```scala
type TAlgebra[M[_], A] = M[A] => A
```

This is just a F-algebra with additional laws relating the action with the monad
methods. It seems that the category of TAlgebras where M is the monad generated
by a free-forget adjunction is isomorphic to the left side category. For
instance, the category of List-algebras is isomorphic to the category of
Monoids.

Its higher order version looks as follows.

```scala
type THAlgebra = Alg[F, ?] ~> F
```

The same idea applies here. Thereby, the category of Free-algebras (Free
construction from scalaz) is isomorphic to the category of Monads.

What does this bring in our context? Well, our apply method is very similar to
the definition of a FreeAlg-algebra. The major difference relies in the fact
that the FreeAlg-algebra returns Q[X] instead of P[X]. Awesome, maybe our apply
is hiding both the algebra and the homomorphism from Q to P!!! Unfortunately,
this is not the case.

First of all, we can't create an instance of an arbitrary Alg. We need to know
the precise signature in order to do so. In this sense, glance at the following
isomorphism where we connect Monads and Free-algebras:

```scala
type THAlgebra[F[_[_], _], X[_]] = F[X, ?] ~> X 

def fromMonad[X[_]: Monad]: THAlgebra[FreeMonad, X] =
  λ[FreeMonad[X, ?] ~> X](_(refl))

def toMonad[X[_]](alg: THAlgebra[FreeMonad, X]): Monad[X] =
  new Monad[X] {
    def point[A](a: => A): X[A] = 
    alg(new FreeMonad[X, A] {
        def apply[Y[_]: Monad](f: X ~> Y): Y[A] = 
        a.point[Y]
    })
    def bind[A, B](fa: X[A])(f: A => X[B]): X[B] =
    alg(new FreeMonad[X, B] {
        def apply[Y[_]: Monad](g: X ~> Y): Y[B] = 
        g(fa) >>= (a => g(f(a)))
    })
  }
```

Of course, we can provide an implementation for `toMonad`, but we need to know
its inner signature to be able to do so, I mean, we need to be aware of
implementing point and bind and we simply don't have access to the inners of
Alg. Beyond that, our new definition for apply breaks the original purpose of
our selector. We are exposing Q!!! By doing so, we are linking the program to a
particular lens algebra and therefore we can't reuse it among different
invocations to different lens algebras. We'll show how to solve this issue in
the next subsection. Before doing so, I provide an additional connection which
was surprising to me.

We already know that we can represent algebras as F-algebras. So, we can use
FreeMonoid to create a free object in the category of MonoidF-algebras. This
adjunction is producing a monad (FreeMonoid or List). Well, if we apply Free
MonoidF we get something isomorphic to List. More generally, the monad that
arises in a free-forgetful adjunction where F-algebras are involved is the same
as the monad that we get when we apply Free over the F component of the
F-algebra. We haven't exploited this connection in the present work, but it
seems promising. You can find more about this in [Many Roads to Free
Monads](https://www.schoolofhaskell.com/user/dolio/many-roads-to-free-monads).


## Selector as an Initial Algebra

So, our original selector was very similar to a Free Algebra, although it was
lacking the embedding function. Therefore I'm afraid I reinvented the initial
algebra for a state algebra. This seems to be all we need to select a method
from an algebra. So we'll rename the abstraction name, which seems to be the
only material contribution from this work (although my spirit is way far richer
:).