### PR TITLE
Provides a filter method

### DIFF
--- a/src/main/scala/TraversalAlgHom.scala
+++ b/src/main/scala/TraversalAlgHom.scala
@@ -16,6 +16,15 @@ trait TraversalAlgHom[Alg[_[_], _], P[_], A] {
       M: Monoid[B]): P[B] =
     apply(f).map(_.suml)
 
+  def filter[B](
+      p: InitialSAlg[Alg, A, Boolean],
+      g: InitialSAlg[Alg, A, B])(implicit
+      F: Functor[P],
+      M: Monad[Q]): P[List[B]] =
+    hom(p(alg).ifM(
+      g(alg).map(_.point[List]), 
+      List.empty[B].point[Q])).run.map(_.suml)
+
   def composeLens[Alg2[_[_], _], B](
       ln: LensAlgHom[Alg2, Q, B]): TraversalAlgHom.Aux[Alg2, P, ln.Q, B] =
     TraversalAlgHom[Alg2, P, ln.Q, B](ln.alg, hom compose ln.hom)


### PR DESCRIPTION
I've created a `filter` operator for `TraversalAlgHom`. It turns out to be useful to implement the examples from Cheneys's paper on Language Integrated Query. This method takes a predicate (represented as a program returning a `Boolean`) and an action to be executed only if the predicate holds (which is also a program). The signature and implementation may vary in the near future but this is good enough to implement a preliminary version of the aforementioned examples using Stateless(er).