### PR TITLE
STAT-35: Dealing with cartesian products

### DIFF
--- a/src/main/scala/core/interpreter/NBE.scala
+++ b/src/main/scala/core/interpreter/NBE.scala
@@ -174,7 +174,7 @@ class NBE extends Statelesser[Semantic] {
 
     // done.copy(vars = aux(done.vars))
 
-    ???
+    done
   }
 
   private def cart[O[_, _], S, A, B](

--- a/src/main/scala/sql-normal/interpreter/ToSql.scala
+++ b/src/main/scala/sql-normal/interpreter/ToSql.scala
@@ -68,7 +68,7 @@ class ToSql {
       ot: OpticType[_, _],
       keys: Map[TypeNme, FieldName]): SqlJoin = SEqJoin(ot.tgt.nme, v, 
     ot match {
-      case FoldType(src, _) => SUsing(keys(src.nme))
+      case FoldType(_, src, _) => SUsing(keys(src.nme))
       case other => condToSql(topv, nme, v, keys(other.tgt.nme))
     })
 

--- a/src/main/scala/sql-normal/interpreter/ToSql.scala
+++ b/src/main/scala/sql-normal/interpreter/ToSql.scala
@@ -41,8 +41,11 @@ class ToSql {
   private def tabToSql[E[_]](
       vars: TVarMap,
       keys: Map[TypeNme, FieldName]): SqlFrom = vars.toList match {
-    case (ot, ITree(v, nodes)) :: Nil =>
-      SFrom(List(STable(ot.tgt.nme, v, seqJoinToSql(v, nodes, keys))))
+    case (ot, ITree(v, nodes)) :: xs =>
+      SFrom(List(STable(ot.tgt.nme, v, xs.foldLeft(seqJoinToSql(v, nodes, keys)) {
+        case (acc, (ot2, ITree(v2, nodes2))) => 
+          acc ::: (SJoin(ot2.tgt.nme, v2) :: seqJoinToSql(v2, nodes2, keys))
+      })))
     case _ =>
       throw new Error(s"Can't translate semantic with multiple roots: $vars")
   }

--- a/src/main/scala/sql-normal/interpreter/ToSql.scala
+++ b/src/main/scala/sql-normal/interpreter/ToSql.scala
@@ -67,10 +67,10 @@ class ToSql {
       v: Symbol,
       ot: OpticType[_, _],
       keys: Map[TypeNme, FieldName]): SqlJoin = SEqJoin(ot.tgt.nme, v, 
-    if (ot.kind == KGetter) 
-      condToSql(topv, nme, v, keys(ot.tgt.nme)) 
-    else 
-      SUsing(keys(ot.src.nme)))
+    ot match {
+      case FoldType(src, _) => SUsing(keys(src.nme))
+      case other => condToSql(topv, nme, v, keys(other.tgt.nme))
+    })
 
   private def whrToSql[S](
       whr: Set[TExpr[S, Boolean]],

--- a/src/main/scala/sql-normal/interpreter/ToSql.scala
+++ b/src/main/scala/sql-normal/interpreter/ToSql.scala
@@ -87,8 +87,8 @@ class ToSql {
       vars: TVarMap,
       keys: Map[TypeNme, FieldName]): SqlExp = t match {
         case Var(op) => op.getOption(vars).fold(???)(it => SAll(it.label))
-    case Select(Var(op), (nme, _)) => 
-      op.getOption(vars).fold(???)(it => SProj(it.label, nme))
+    case Select(Var(op), ot) => 
+      op.getOption(vars).fold(???)(it => SProj(it.label, ot.nme))
     case Sub(l, r, _) => 
       SBinOp("-", treeToExpr(l, vars, keys), treeToExpr(r, vars, keys))
     case Gt(l, r, _) => 

--- a/src/main/scala/sql-normal/itree.scala
+++ b/src/main/scala/sql-normal/itree.scala
@@ -1,14 +1,11 @@
 package statelesser
 package sqlnormal
 
-import monocle._, function.Index
+import monocle._, function.Index, Index._
 
 case class ITree[I, A](
-    label: A, 
-    children: IForest[I, A] = Map.empty[I, ITree[I, A]]) {
-
-  def contains(a: A): Boolean = ???
-}
+  label: A, 
+  children: IForest[I, A] = Map.empty[I, ITree[I, A]])
 
 object ITree {
   
@@ -16,8 +13,8 @@ object ITree {
     
     def index(i: I): Optional[ITree[I, A], ITree[I, A]] =
       Optional[ITree[I, A], ITree[I, A]](
-        s => s.children.get(i))(
-        a => s => s.copy(children = s.children.updated(i, a)))
+        s => mapIndex.index(i).getOption(s.children))(
+        a => s => s.copy(children = mapIndex.index(i).set(a)(s.children)))
   }
 }
 

--- a/src/main/scala/sql-normal/itree.scala
+++ b/src/main/scala/sql-normal/itree.scala
@@ -4,8 +4,11 @@ package sqlnormal
 import monocle._, function.Index, Index._
 
 case class ITree[I, A](
-  label: A, 
-  children: IForest[I, A] = Map.empty[I, ITree[I, A]])
+    label: A, 
+    children: IForest[I, A] = Map.empty[I, ITree[I, A]]) {
+  def exists(p: A => Boolean): Boolean =
+    p(label) || children.values.toList.exists(_.exists(p)) 
+}
 
 object ITree {
   

--- a/src/main/scala/sql-normal/package.scala
+++ b/src/main/scala/sql-normal/package.scala
@@ -21,24 +21,8 @@ package object `sqlnormal` {
 
   type IForest[I, A] = Map[I, ITree[I, A]]
 
-  type TVarTree = NonEmptyList[ITree[String, (Symbol, OpticType[_, _])]]
+  type TVarTree = ITree[OpticType[_, _], Symbol]
 
-  implicit val indexTVarTree = 
-    new Index[TVarTree, Symbol, ITree[String, (Symbol, OpticType[_, _])]] {
-      def index(i: Symbol) = 
-        Optional[TVarTree, ITree[String, (Symbol, OpticType[_, _])]](
-          s => s.list.find(_.label._1 == i))(
-          a => s => 
-            if (s.head.label._1 == i) 
-              NonEmptyList.nel(a.copy(label = (i, a.label._2)), s.tail) 
-            else 
-              NonEmptyList.nel(
-                s.head, 
-                iMapIndex[Symbol, ITree[String, (Symbol, OpticType[_, _])]]
-                  .index(i)
-                  .set(
-                    a.copy(label = (i, a.label._2)))(
-                    s.tail.map(t => (t.label._1, t)).toMap).toIList))
-    }
+  type TVarMap = IForest[OpticType[_, _], Symbol]
 }
 

--- a/src/main/scala/sql-normal/package.scala
+++ b/src/main/scala/sql-normal/package.scala
@@ -9,8 +9,6 @@ package object `sqlnormal` {
 
   type OpticNme = String
 
-  type Value = OpticType[_, _] \/ Select[_, _, _]
-
   type Semantic[A] = State[Stream[Symbol], TSemantic[A]]
 
   type Symbol = String

--- a/src/main/scala/sql-normal/texpr.scala
+++ b/src/main/scala/sql-normal/texpr.scala
@@ -45,7 +45,7 @@ case class Var[S, A](op: Optional[TVarMap, TVarTree]) extends TExpr[S, A]
 
 case class Select[S, A, B](
   v: Var[S, A], 
-  label: (String, OpticType[A, B])) extends TExpr[S, B]
+  label: OpticType[A, B]) extends TExpr[S, B]
 
 case class Not[S, A](
   b: TExpr[S, Boolean], 

--- a/src/main/scala/sql-normal/texpr.scala
+++ b/src/main/scala/sql-normal/texpr.scala
@@ -6,7 +6,7 @@ import monocle.Optional
 
 sealed abstract class TExpr[S, A] {
 
-  def vars: Set[Optional[TVarTree, ITree[String, (Symbol, OpticType[_, _])]]] = 
+  def vars: Set[Optional[TVarMap, TVarTree]] = 
     this match {
       case Var(op) => Set(op)
       case Select(v, _) => v.vars
@@ -41,8 +41,7 @@ case class LikeBool[S](b: Boolean) extends TExpr[S, Boolean]
 
 case class LikeStr[S](s: String) extends TExpr[S, String]
 
-case class Var[S, A](
-  op: Optional[TVarTree, ITree[String, (Symbol, OpticType[_, _])]]) extends TExpr[S, A]
+case class Var[S, A](op: Optional[TVarMap, TVarTree]) extends TExpr[S, A]
 
 case class Select[S, A, B](
   v: Var[S, A], 

--- a/src/main/scala/sql-normal/toptic.scala
+++ b/src/main/scala/sql-normal/toptic.scala
@@ -1,15 +1,27 @@
 package statelesser
 package sqlnormal
 
-sealed abstract class OpticKind
-case object KGetter extends OpticKind
-case object KAffineFold extends OpticKind
-case object KFold extends OpticKind
-
 case class TypeInfo(nme: TypeNme, isPrimitive: Boolean = false)
 
-case class OpticType[S, A](
-  kind: OpticKind, 
+sealed abstract class OpticType[S, A] {
+  val src: TypeInfo
+  val tgt: TypeInfo
+}
+
+case class GetterType[S, A](
   src: TypeInfo, 
-  tgt: TypeInfo)
+  tgt: TypeInfo) extends OpticType[S, A]
+
+case class AffineFoldType[S, A](
+  src: TypeInfo, 
+  tgt: TypeInfo) extends OpticType[S, A]
+
+case class FoldType[S, A](
+    src: TypeInfo, 
+    tgt: TypeInfo) extends OpticType[S, A] {
+  override def equals(that: Any): Boolean = that match {
+    case other: FoldType[S, A] => this eq other
+    case _ => false
+  }
+}
 

--- a/src/main/scala/sql-normal/toptic.scala
+++ b/src/main/scala/sql-normal/toptic.scala
@@ -4,19 +4,23 @@ package sqlnormal
 case class TypeInfo(nme: TypeNme, isPrimitive: Boolean = false)
 
 sealed abstract class OpticType[S, A] {
+  val nme: String
   val src: TypeInfo
   val tgt: TypeInfo
 }
 
 case class GetterType[S, A](
+  nme: String,
   src: TypeInfo, 
   tgt: TypeInfo) extends OpticType[S, A]
 
 case class AffineFoldType[S, A](
+  nme: String,
   src: TypeInfo, 
   tgt: TypeInfo) extends OpticType[S, A]
 
 case class FoldType[S, A](
+    nme: String,
     src: TypeInfo, 
     tgt: TypeInfo) extends OpticType[S, A] {
   override def equals(that: Any): Boolean = that match {

--- a/src/main/scala/sql-normal/toptic.scala
+++ b/src/main/scala/sql-normal/toptic.scala
@@ -24,7 +24,7 @@ case class FoldType[S, A](
     src: TypeInfo, 
     tgt: TypeInfo) extends OpticType[S, A] {
   override def equals(that: Any): Boolean = that match {
-    case other: FoldType[S, A] => this eq other
+    case other: AnyRef => this eq other
     case _ => false
   }
 }

--- a/src/main/scala/sql-normal/tsel.scala
+++ b/src/main/scala/sql-normal/tsel.scala
@@ -6,11 +6,10 @@ import monocle.Optional
 
 sealed abstract class TSel[S, A] {
 
-  def vars: Set[Optional[TVarTree, ITree[String, (Symbol, OpticType[_, _])]]] = 
-    this match {
-      case Pair(l, r, _) => l.vars ++ r.vars
-      case Just(e) => e.vars
-    }
+  def vars: Set[Optional[TVarMap, TVarTree]] = this match {
+    case Pair(l, r, _) => l.vars ++ r.vars
+    case Just(e) => e.vars
+  }
 }
 
 case class Just[S, A](e: TExpr[S, A]) extends TSel[S, A]

--- a/src/main/scala/sql-normal/tsemantic.scala
+++ b/src/main/scala/sql-normal/tsemantic.scala
@@ -14,10 +14,9 @@ object TSemantic {
 }
 
 case class Done[O[_, _], S, A](
-  expr: TSel[S, A], 
-  filt: Set[TExpr[S, Boolean]],
-  vars: TVarTree) extends TSemantic[O[S, A]] {
-
+    expr: TSel[S, A], 
+    filt: Set[TExpr[S, Boolean]],
+    vars: TVarMap) extends TSemantic[O[S, A]] {
   def as[O2[_, _]]: Done[O2, S, A] = Done(expr, filt, vars)
 }
 

--- a/src/main/scala/sql/stateless.sql
+++ b/src/main/scala/sql/stateless.sql
@@ -1,0 +1,134 @@
+-- MySQL dump 10.16  Distrib 10.1.37-MariaDB, for Linux (x86_64)
+--
+-- Host: localhost    Database: stateless
+-- ------------------------------------------------------
+-- Server version	10.1.37-MariaDB
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `Address`
+--
+
+DROP TABLE IF EXISTS `Address`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Address` (
+  `address_id` smallint(6) NOT NULL,
+  `street` varchar(30) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`address_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Address`
+--
+
+LOCK TABLES `Address` WRITE;
+/*!40000 ALTER TABLE `Address` DISABLE KEYS */;
+/*!40000 ALTER TABLE `Address` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Alias`
+--
+
+DROP TABLE IF EXISTS `Alias`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Alias` (
+  `alias_id` smallint(6) DEFAULT NULL,
+  `alias` varchar(30) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `person_id` smallint(6) DEFAULT NULL,
+  KEY `person_id` (`person_id`),
+  CONSTRAINT `Alias_ibfk_1` FOREIGN KEY (`person_id`) REFERENCES `Person` (`person_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Alias`
+--
+
+LOCK TABLES `Alias` WRITE;
+/*!40000 ALTER TABLE `Alias` DISABLE KEYS */;
+INSERT INTO `Alias` VALUES (0,'A',0),(1,'B',1),(2,'A-her',0),(3,'C',2);
+/*!40000 ALTER TABLE `Alias` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Couple`
+--
+
+DROP TABLE IF EXISTS `Couple`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Couple` (
+  `couple_id` smallint(6) NOT NULL,
+  `her` smallint(6) DEFAULT NULL,
+  `him` smallint(6) DEFAULT NULL,
+  PRIMARY KEY (`couple_id`),
+  KEY `fk_her` (`her`),
+  KEY `fk_him` (`him`),
+  CONSTRAINT `fk_her` FOREIGN KEY (`her`) REFERENCES `Person` (`person_id`),
+  CONSTRAINT `fk_him` FOREIGN KEY (`him`) REFERENCES `Person` (`person_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Couple`
+--
+
+LOCK TABLES `Couple` WRITE;
+/*!40000 ALTER TABLE `Couple` DISABLE KEYS */;
+INSERT INTO `Couple` VALUES (0,0,1),(1,2,3),(2,4,5);
+/*!40000 ALTER TABLE `Couple` ENABLE KEYS */;
+UNLOCK TABLES;
+
+--
+-- Table structure for table `Person`
+--
+
+DROP TABLE IF EXISTS `Person`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `Person` (
+  `person_id` smallint(6) NOT NULL,
+  `name` varchar(30) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `age` smallint(6) DEFAULT NULL,
+  `weight` smallint(6) DEFAULT NULL,
+  `address` smallint(6) DEFAULT NULL,
+  PRIMARY KEY (`person_id`),
+  KEY `fk_person_address` (`address`),
+  CONSTRAINT `fk_person_address` FOREIGN KEY (`address`) REFERENCES `Address` (`address_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `Person`
+--
+
+LOCK TABLES `Person` WRITE;
+/*!40000 ALTER TABLE `Person` DISABLE KEYS */;
+INSERT INTO `Person` VALUES (0,'Alex',60,60,NULL),(1,'Bert',55,55,NULL),(2,'Cora',33,33,NULL),(3,'Drew',31,31,NULL),(4,'Edna',21,21,NULL),(5,'Fred',60,60,NULL);
+/*!40000 ALTER TABLE `Person` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2019-01-23 15:51:56

--- a/src/test/scala/CoupleExample.scala
+++ b/src/test/scala/CoupleExample.scala
@@ -223,34 +223,34 @@ object CoupleExample {
         }
       }))
 
-    val couples = assignRoot(
+    def couples = assignRoot(
       FoldType("couples", TypeInfo("Couples"), TypeInfo("Couple", true)))
 
-    val her = assignNode(
+    def her = assignNode(
       GetterType("her", TypeInfo("Couple", true), TypeInfo("Person", true)))
 
-    val him = assignNode(
+    def him = assignNode(
       GetterType("him", TypeInfo("Couple", true), TypeInfo("Person", true)))
 
-    val people = assignRoot(
+    def people = assignRoot(
       FoldType("people", TypeInfo("People"), TypeInfo("Person", true)))
 
-    val name = assignLeaf(
+    def name = assignLeaf(
       GetterType("name", TypeInfo("Person", true), TypeInfo("String")))
 
-    val age = assignLeaf(
+    def age = assignLeaf(
       GetterType("age", TypeInfo("Person", true), TypeInfo("Int")))
 
-    val weight = assignLeaf(
+    def weight = assignLeaf(
       GetterType("weight", TypeInfo("Person", true), TypeInfo("Int")))
 
-    val address = assignNode(
+    def address = assignNode(
       GetterType("address", TypeInfo("Person", true), TypeInfo("Address", true)))
 
-    val aliases = assignNode(
+    def aliases = assignNode(
       FoldType("aliases", TypeInfo("Person", true), TypeInfo("Alias", true)))
 
-    val street = assignLeaf(
+    def street = assignLeaf(
       GetterType("street", TypeInfo("Address", true), TypeInfo("String")))
   }
 }

--- a/src/test/scala/CoupleExample.scala
+++ b/src/test/scala/CoupleExample.scala
@@ -209,7 +209,7 @@ object CoupleExample {
             Just(Var(op.composeOptional(indexITree.index(ot)))), 
             done.filt, 
             op.modify(
-              it => it.copy(children = it.children + (key -> ITree((s, ot)))))(
+              it => it.copy(children = it.children + (ot -> ITree(s))))(
               done.vars))
         }
       }))

--- a/src/test/scala/CoupleExample.scala
+++ b/src/test/scala/CoupleExample.scala
@@ -59,25 +59,6 @@ trait CoupleExample[Expr[_]] {
       first >
       second).asFold
 
-  // def getPeopleName_3: Expr[People => List[String]] =
-  //   getAll(people > (((name * age) * weight > first) > first).asFold)
-
-  // def getPeopleName_4: Expr[People => List[String]] =
-  //   getAll(people > (((name * age) * weight > (first > first))).asFold)
-
-  // def getPeopleName_5: Expr[People => List[String]] =
-  //   getAll(people > (name * (age * weight) > (first > id)).asFold)
-
-  // def getPeopleName_6: Expr[People => List[String]] =
-  //   getAll(people >
-  //     (name * weight * age * name * weight >
-  //     id >
-  //     second * first >
-  //     second * first >
-  //     first * id >
-  //     first >
-  //     second).asFold)
-
   def getPeopleNameAnd3_1: Expr[Fold[People, (String, Int)]] =
     people > (name * likeInt(3)).asFold
 
@@ -152,10 +133,6 @@ trait CoupleExample[Expr[_]] {
   def getHerNameGt30_2: Expr[Fold[Couples, String]] =
     couples > ((her > name).asAffineFold <*
       ((her > age).asAffineFold > filtered (gt(30)))).asFold
-
-  // def differenceAll: Expr[Couples => List[(String, Int)]] =
-  //   getAll(couples >
-  //     ((her > name) * ((her > age) * (him > age) > sub)).asFold)
 
   def difference: Expr[Fold[Couples, (String, Int)]] =
     couples >

--- a/src/test/scala/CoupleExample.scala
+++ b/src/test/scala/CoupleExample.scala
@@ -224,34 +224,34 @@ object CoupleExample {
       }))
 
     val couples = assignRoot(
-      OpticType(KFold, TypeInfo("Couples"), TypeInfo("Couple", true)))
+      FoldType(TypeInfo("Couples"), TypeInfo("Couple", true)))
 
     val her = assignNode("her",
-      OpticType(KGetter, TypeInfo("Couple", true), TypeInfo("Person", true)))
+      GetterType(TypeInfo("Couple", true), TypeInfo("Person", true)))
 
     val him = assignNode("him",
-      OpticType(KGetter, TypeInfo("Couple", true), TypeInfo("Person", true)))
+      GetterType(TypeInfo("Couple", true), TypeInfo("Person", true)))
 
     val people = assignRoot(
-      OpticType(KFold, TypeInfo("People"), TypeInfo("Person", true)))
+      FoldType(TypeInfo("People"), TypeInfo("Person", true)))
 
     val name = assignLeaf("name",
-      OpticType(KGetter, TypeInfo("Person", true), TypeInfo("String")))
+      GetterType(TypeInfo("Person", true), TypeInfo("String")))
 
     val age = assignLeaf("age",
-      OpticType(KGetter, TypeInfo("Person", true), TypeInfo("Int")))
+      GetterType(TypeInfo("Person", true), TypeInfo("Int")))
 
     val weight = assignLeaf("weight",
-      OpticType(KGetter, TypeInfo("Person", true), TypeInfo("Int")))
+      GetterType(TypeInfo("Person", true), TypeInfo("Int")))
 
     val address = assignNode("address",
-      OpticType(KGetter, TypeInfo("Person", true), TypeInfo("Address", true)))
+      GetterType(TypeInfo("Person", true), TypeInfo("Address", true)))
 
     val aliases = assignNode("aliases",
-      OpticType(KFold, TypeInfo("Person", true), TypeInfo("String")))
+      FoldType(TypeInfo("Person", true), TypeInfo("String")))
 
     val street = assignLeaf("street",
-      OpticType(KGetter, TypeInfo("Address", true), TypeInfo("String")))
+      GetterType(TypeInfo("Address", true), TypeInfo("String")))
   }
 }
 

--- a/src/test/scala/CoupleExample.scala
+++ b/src/test/scala/CoupleExample.scala
@@ -165,8 +165,11 @@ trait CoupleExample[Expr[_]] {
           id * (likeInt[Int](41) * likeInt[Int](1) > sub)
             > greaterThan)))).asFold
 
-  def getHerCartesianAliases: Expr[Fold[Couples, (String, String)]] =
+  def getHerCartesianAliases_1: Expr[Fold[Couples, (String, String)]] =
     couples > her.asFold > aliases * aliases
+
+  def getHerCartesianAliases_2: Expr[Fold[Couples, (String, String)]] =
+    couples > (her.asFold > aliases) * (her.asFold > aliases)
 }
 
 object CoupleExample {

--- a/src/test/scala/CoupleExample.scala
+++ b/src/test/scala/CoupleExample.scala
@@ -224,34 +224,34 @@ object CoupleExample {
       }))
 
     val couples = assignRoot(
-      FoldType(TypeInfo("Couples"), TypeInfo("Couple", true)))
+      FoldType("couples", TypeInfo("Couples"), TypeInfo("Couple", true)))
 
     val her = assignNode("her",
-      GetterType(TypeInfo("Couple", true), TypeInfo("Person", true)))
+      GetterType("her", TypeInfo("Couple", true), TypeInfo("Person", true)))
 
     val him = assignNode("him",
-      GetterType(TypeInfo("Couple", true), TypeInfo("Person", true)))
+      GetterType("him", TypeInfo("Couple", true), TypeInfo("Person", true)))
 
     val people = assignRoot(
-      FoldType(TypeInfo("People"), TypeInfo("Person", true)))
+      FoldType("people", TypeInfo("People"), TypeInfo("Person", true)))
 
     val name = assignLeaf("name",
-      GetterType(TypeInfo("Person", true), TypeInfo("String")))
+      GetterType("name", TypeInfo("Person", true), TypeInfo("String")))
 
     val age = assignLeaf("age",
-      GetterType(TypeInfo("Person", true), TypeInfo("Int")))
+      GetterType("age", TypeInfo("Person", true), TypeInfo("Int")))
 
     val weight = assignLeaf("weight",
-      GetterType(TypeInfo("Person", true), TypeInfo("Int")))
+      GetterType("weight", TypeInfo("Person", true), TypeInfo("Int")))
 
     val address = assignNode("address",
-      GetterType(TypeInfo("Person", true), TypeInfo("Address", true)))
+      GetterType("address", TypeInfo("Person", true), TypeInfo("Address", true)))
 
     val aliases = assignNode("aliases",
-      FoldType(TypeInfo("Person", true), TypeInfo("String")))
+      FoldType("aliases", TypeInfo("Person", true), TypeInfo("String")))
 
     val street = assignLeaf("street",
-      GetterType(TypeInfo("Address", true), TypeInfo("String")))
+      GetterType("street", TypeInfo("Address", true), TypeInfo("String")))
   }
 }
 

--- a/src/test/scala/sql/CoupleExampleTest.scala
+++ b/src/test/scala/sql/CoupleExampleTest.scala
@@ -124,7 +124,7 @@ class CoupleExampleTest extends FlatSpec with Matchers {
   }
 
   it should "generate cartesian product when achieving fold products" in {
-    matchSql(raw"".r, getHerCartesianAliases)
+    matchSql(raw"".r, /*getHerCartesianAliases_1,*/ getHerCartesianAliases_2)
   }
 
   it should "generate cartesian product in the root, aka. JOIN" in {

--- a/src/test/scala/sql/CoupleExampleTest.scala
+++ b/src/test/scala/sql/CoupleExampleTest.scala
@@ -126,5 +126,9 @@ class CoupleExampleTest extends FlatSpec with Matchers {
   it should "generate cartesian product when achieving fold products" in {
     matchSql(raw"".r, getHerCartesianAliases)
   }
+
+  it should "generate cartesian product in the root, aka. JOIN" in {
+    matchSql(raw"".r, difference_1)
+  }
 }
 

--- a/src/test/scala/sql/CoupleExampleTest.scala
+++ b/src/test/scala/sql/CoupleExampleTest.scala
@@ -122,5 +122,9 @@ class CoupleExampleTest extends FlatSpec with Matchers {
       raw"SELECT (.+)\.street, (.+)\.street FROM Couple AS (.+) INNER JOIN Person AS (.+) ON \3\.her = \4\.name INNER JOIN Address AS \1 ON \4\.address = \1\.id INNER JOIN Person AS (.+) ON \3\.him = \5\.name INNER JOIN Address AS \2 ON \5\.address = \2.id;".r, 
       herAndHimStreet_1)
   }
+
+  it should "generate cartesian product when achieving fold products" in {
+    matchSql(raw"".r, getHerCartesianAliases)
+  }
 }
 


### PR DESCRIPTION
Mainly, this work clarifies the connections between fold products and cartesian product sql statements. As we have seen, we get the cartesian product when we separate identifiers in the normal form. That's why `FoldType` provides an `equals` method which is based on `eq` (reference equality). I've added a few queries which are running nicely in the database. Tests aren't passing because testing against regular expressions is prone to fail, so I've decided to delegate these aspects to the incoming PureTest specification.

https://hablapps.atlassian.net/browse/STAT-35